### PR TITLE
fix: don't index nil diagnostic value

### DIFF
--- a/lua/neodim/init.lua
+++ b/lua/neodim/init.lua
@@ -37,7 +37,7 @@ end
 
 local is_unused = function(diagnostic)
   if diagnostic.severity == vim.diagnostic.severity.HINT then
-    local tags = diagnostic.tags or diagnostic.user_data.lsp.tags
+    local tags = diagnostic.tags or vim.tbl_get(diagnostic, "user_data", "lsp", "tags")
     return tags and vim.tbl_contains(tags, vim.lsp.protocol.DiagnosticTag.Unnecessary)
   end
   return false


### PR DESCRIPTION
Ran into errors with `shellcheck` via `null-ls`, where it's receiving a diagnostic object like:

```lua
{
  bufnr = 1,
  code = 2006,
  col = 6,
  end_col = 13,
  end_lnum = 5,
  end_row = 6,
  lnum = 5,
  message = "Use $(...) notation instead of legacy backticks `...`.",
  namespace = 35,
  row = 6,
  severity = 4,
  source = "shellcheck"
}
```

**Important: Note that `vim.tbl_get` is not part of 0.7.0, not sure what neovim runtime version this plugin targets**