### PR TITLE
docs: add neodim.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,118 +1,76 @@
 # neodim
+
 Neovim plugin for dimming the highlights of unused functions, variables, parameters, and more
 
-This plugin takes heavy inspiration from https://github.com/NarutoXY/dim.lua. The implementation in NarutoXY/dim.lua was a bit inefficient and I saw room for various improvements, including making the dimming an actual LSP handler, rather than an autocmd. The result is a much more polished experience with greater efficiency.
 
-### Setup:
+## Requirements
 
-Neovim 0.10.0 is required for this plugin to work properly.
+- **Neovim** ≧ 0.10.0
+- **Treesitter**
+- **Language server** supporting [DiagnosticTag](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnosticTag)
+
+## Installation
+
+The following is an example of using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
-{
-  "zbirenbaum/neodim",
-  event = "LspAttach",
-  config = function()
-    require("neodim").setup({
-      refresh_delay = 75,
-      alpha = 0.75,
-      blend_color = "#000000",
-      hide = {
-        underline = true,
-        virtual_text = true,
-        signs = true,
-      },
-      regex = {
-        "[uU]nused",
-        "[nN]ever [rR]ead",
-        "[nN]ot [rR]ead",
-      },
-      priority = 128,
-      disable = {},
-    })
-  end
-}
+require("lazy").setup(
+  -- ...
+  {
+    "zbirenbaum/neodim",
+    event = "LspAttach",  -- remove this if you don't want to lazy loading
+    config = function()
+      require("neodim").setup()
+    end,
+  },
+  -- ...
+)
 ```
 
-### Options:
+## Options
 
-#### Dim Highlight Options
+You can pass options to the `setup()` function.
 
-##### alpha
-
-`alpha` controls how dim the highlight becomes. A value of 1 means that dimming will do nothing at all, while a value of 0 will make it identical to #000000 or the color set in `blend_color`. Conceptually, if you were to place the text to be dimmed on a background of `blend_color`, and then set the opacity of the text to the value of alpha, you would have the resulting color that the plugin highlights with.
-
+Example (**not a default value**):
 
 ```lua
 require("neodim").setup({
-  alpha = 0.5 -- make the dimmed text even dimmer
-})
-```
-
-##### blend_color
-
-`blend_color` controls the color which is used to dim your highlight. Black is the default, but you could set this to your terminal or neovim background color to make it more seamless.
-
-Example:
-
-```lua
-require("neodim").setup({
-  blend_color = "#10171f"
-})
-```
-
-#### regex
-
-If the diagnostic message matches one of these, the code to which the
-diagnostic refers is dimmed.
-
-You can set up each filetype by entering in a table with the key as the filetype.
-
-Example:
-```lua
-  require("neodim").setup({
-    regex = {
-      "[Uu]nused",
-      cs = {
-        "CS8019",
-      },
-      -- disable `regex` option when filetype is "rust"
-      rust = {},
-    }
-  })
-```
-
-#### Decoration Options
-All decorations can be hidden for diagnostics pertaining to unused tokens. By default, hiding all of them is enabled, but you can re-enable them by changing the config table passed to neodim. It is important to note that regardless of what you put in this configuration, neodim will always respect settings created with `vim.diagnostic.config`. For example, if all underline decorations are disabled by running `vim.diagnostic.config({ underline=false })`, neodim will ***not*** re-enable them for "unused" diagnostics.
-
-Example:
-
-```lua
--- re-enable only sign decorations for 'unused' diagnostics
-require("neodim").setup({
-  hide = { signs = false }
-})
-```
-
-```lua
--- renable all decorations for 'unused' diagnostics
-require("neodim").setup({
+  alpha = 0.75,
+  blend_color = "#000000",
+  
   hide = {
-    virtual_text = false,
     signs = false,
-    underline = false,
-  }
+    -- disable underline in dimmed text
+    underline = true,
+    virtual_text = false,
+  },
+  
+  disable = {
+    -- disable when filetype is "python" or "swift"
+    "python",
+    "swift",
+  },
+
+  -- don't need to be set if you have all the `Requirements`
+  regex = {
+    "[Uu]nused",
+    cs = {
+      "CS8019",
+    },
+    rust = {},
+  },
+
+  -- priority of extmarks used for highlight
+  priority = 128,
+  
+  refresh_delay = 75,
 })
 ```
 
-<!-- ### How to get live dim updates as you type -->
-<!---->
-<!-- The vim.diagnostic.config function provides hooks which allow you to affect the behavior of this plugin. Setting `update_in_insert` to true will cause the plugin to update as fast as your LSP can supply diagnostic info. I personally find it preferable to keep this value at false, but the option is there and I recommend trying both out to see which you prefer. -->
-<!---->
-<!-- Example: -->
-<!-- ``` -->
-<!-- vim.diagnostic.config({ -->
-<!--   ... -->
-<!--   update_in_insert = true, -- Set this to true for live dim updates as you type -->
-<!--   ... -->
-<!-- }) -->
-<!-- ``` -->
+Please see [`:help neodim-options`](./doc/neodim.txt) for more details.
+
+## Documentation
+
+```vim
+:help neodim
+```

--- a/doc/neodim.txt
+++ b/doc/neodim.txt
@@ -1,0 +1,134 @@
+*neodim.txt*   Neovim plugin for dimming the highlights of unused codes
+
+==============================================================================
+ABOUT                                                             *neodim-about*
+
+This plugin takes heavy inspiration from https://github.com/NarutoXY/dim.lua.
+
+The implementation in NarutoXY/dim.lua was a bit inefficient and I saw room
+for various improvements, including making the dimming an actual LSP handler,
+rather than an autocmd.
+The result is a much more polished experience with greater efficiency.
+
+
+==============================================================================
+REQUIREMENTS                                               *neodim-requirements*
+
+- Neovim ≧ 0.10.0
+- Treesitter
+- Language server supporting DiagnosticTag
+  https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnosticTag
+
+
+==============================================================================
+OPTIONS                                                         *neodim-options*
+
+You can pass options to the `setup()` function.
+
+Default value ~
+                                                        *neodim-options-default*
+>lua
+    require("neodim").setup({
+        refresh_delay = 75,
+        alpha = 0.75,
+        blend_color = <background color of `Normal` highlight>,
+        hide = {
+            underline = true,
+            virtual_text = true,
+            signs = true,
+        },
+        priority = 128,
+        disable = {},
+        regex = {
+            "[uU]nused",
+            "[nN]ever [rR]ead",
+            "[nN]ot [rR]ead",
+        },
+    })
+<
+
+alpha ~
+                                                           *neodim-option-alpha*
+
+`alpha` controls how dim the highlight becomes.
+
+A value of 1 means that dimming will do nothing at all, while a value of 0 will
+make it identical to the color set in `blend_color`.
+
+Conceptually, if you were to place the text to be dimmed on a background of
+`blend_color`, and then set the opacity of the text to the value of alpha, you
+would have the resulting color that the plugin highlights with.
+
+blend_color ~
+                                                     *neodim-option-blend_color*
+
+`blend_color` controls the color which is used to dim your highlight.
+
+disable ~
+                                                         *neodim-option-disable*
+
+List of filetypes to disable neodim.
+
+hide ~
+                                                            *neodim-option-hide*
+
+All decorations can be hidden for diagnostics pertaining to unused tokens.
+
+By default, hiding all of them is enabled, but you can re-enable them by
+changing the config table passed to neodim. It is important to note that
+regardless of what you put in this configuration, neodim will always respect
+settings created with `vim.diagnostic.config`. For example, if all underline
+decorations are disabled by running `vim.diagnostic.config({ underline=false })`,
+neodim will NOT re-enable them for "unused" diagnostics.
+
+Example:
+>lua
+    -- re-enable only sign decorations for 'unused' diagnostics
+    require("neodim").setup({
+        hide = { signs = false }
+    })
+
+    -- re-enable all decorations for 'unused' diagnostics
+    require("neodim").setup({
+        hide = {
+            virtual_text = false,
+            signs = false,
+            underline = false,
+        }
+    })
+<
+
+priority ~
+                                                        *neodim-option-priority*
+
+A priority of extmarks used for highlight.
+
+
+refresh_delay ~
+                                                   *neodim-option-refresh_delay*
+
+milli seconds
+
+regex ~
+                                                           *neodim-option-regex*
+
+If the diagnostic message matches one of these, the code to which the
+diagnostic refers is dimmed.
+
+You can set each filetype by entering in a table with the key as the filetype.
+
+Example:
+>lua
+    require("neodim").setup({
+        regex = {
+            "[Uu]nused",
+
+            -- disable `regex` option when filetype is "rust"
+            rust = {},
+        }
+    })
+<
+
+
+==============================================================================
+vim:tw=78:sw=4:ts=4:ft=help:norl:


### PR DESCRIPTION
README.md is what we will primarily see when installing the plugin.

Even if we want to check the README to see how to configure a plugin, we have to open a browser or go to the plugin's directory, which is tedious.
Not many plugin managers generate a helptag in the README header like lazy.nvim does. So I thought there should be a help file separate from the README.

However, I am not good at English, so if there are any missing explanations or incorrect sentences, I would like you to correct them.

If you don't need help file, I will remove this branch.