### PR TITLE
Fix nvim 0.11

### DIFF
--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -164,7 +164,7 @@ end
 ---@return boolean
 TSOverride.override_mark_with_lsp = function(self, mark, buf, start_row, start_col)
   local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, start_row, start_col)
-  if sttoken_mark_data and self:is_unused(buf, start_row, start_col) then
+  if sttoken_mark_data then
     mark.hl_group = self:get_dim_color(sttoken_mark_data.hl_opts, sttoken_mark_data.hl_name)
     mark.priority = config.opts.priority
     return true
@@ -188,16 +188,12 @@ TSOverride.override_mark_with_ts = function(self, mark, buf, start_row, start_co
   end
   ---@diagnostic disable-next-line: invisible
   local capture_name = hl_query:query().captures[capture]
-
-  if self:is_unused(buf, start_row, start_col) then
-    mark.hl_group = self:get_dim_color(
-      vim.api.nvim_get_hl(0, { id = hl, link = false }) --[[@as vim.api.keyset.highlight]],
-      '@' .. capture_name
-    )
-    mark.priority = config.opts.priority
-    return true
-  end
-  return false
+  mark.hl_group = self:get_dim_color(
+    vim.api.nvim_get_hl(0, { id = hl, link = false }) --[[@as vim.api.keyset.highlight]],
+    '@' .. capture_name
+  )
+  mark.priority = config.opts.priority
+  return true
 end
 
 ---@param highlighter vim.treesitter.highlighter
@@ -246,8 +242,11 @@ TSOverride.on_range_impl = function(
         ephemeral = true,
       }
       if
-          self:override_mark_with_lsp(mark, buf, start_row, start_col)
-          or self:override_mark_with_ts(mark, buf, start_row, start_col, state.highlighter_query, capture, metadata)
+          self:is_unused(buf, start_row, start_col)
+          and (
+            self:override_mark_with_lsp(mark, buf, start_row, start_col)
+            or self:override_mark_with_ts(mark, buf, start_row, start_col, state.highlighter_query, capture, metadata)
+          )
       then
         vim.api.nvim_buf_set_extmark(buf, NAMESPACE, start_row, start_col, mark)
       end

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -205,18 +205,8 @@ TSOverride.on_line_impl = function(self, highlighter, buf, line)
       return
     end
 
-    if state.iter == nil or state.next_row < line then
-      ---@diagnostic disable-next-line: invisible
-      state.iter = state.highlighter_query:query():iter_captures(root_node, highlighter.bufnr, line, root_end_row + 1)
-    end
-
-    while state.next_row <= line do
-      local capture, node, metadata = state.iter()
-
-      if capture == nil then
-        break
-      end
-
+    local query = state.highlighter_query:query()
+    for capture, node, metadata in query:iter_captures(root_node, highlighter.bufnr, line, line + 1) do
       local range = vim.treesitter.get_range(node, buf, metadata[capture])
       ---@type integer, integer, integer, integer
       local start_row, start_col, end_row, end_col = Range.unpack4(range)
@@ -235,10 +225,6 @@ TSOverride.on_line_impl = function(self, highlighter, buf, line)
         then
           vim.api.nvim_buf_set_extmark(buf, NAMESPACE, start_row, start_col, mark)
         end
-      end
-
-      if line < start_row then
-        state.next_row = start_row
       end
     end
   end)

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -48,15 +48,16 @@ end
 
 ---@return function
 TSOverride.set_override = function(self)
+  ---@param win integer
   ---@param buf integer
   ---@param line integer
-  local function on_line(_, _, buf, line)
+  local function on_line(_, win, buf, line)
     local highlighter = TSHighlighter.active[buf]
     if not highlighter then
       return
     end
 
-    self:on_line_impl(highlighter, buf, line)
+    self:on_line_impl(highlighter, win, buf, line)
   end
 
   return on_line
@@ -193,11 +194,11 @@ TSOverride.override_mark_with_ts = function(self, mark, buf, start_row, start_co
 end
 
 ---@param highlighter vim.treesitter.highlighter
+---@param win integer
 ---@param buf integer
 ---@param line integer
-TSOverride.on_line_impl = function(self, highlighter, buf, line)
-  ---@diagnostic disable-next-line: invisible
-  highlighter:for_each_highlight_state(function(state)
+TSOverride.on_line_impl = function(self, highlighter, win, buf, line)
+  local function callback(state)
     local root_node = state.tstree:root()
 
     local root_start_row, _, root_end_row, _ = root_node:range()
@@ -227,7 +228,14 @@ TSOverride.on_line_impl = function(self, highlighter, buf, line)
         end
       end
     end
-  end)
+  end
+  if vim.fn.has 'nvim-0.11.3' == 1 then
+    ---@diagnostic disable-next-line: invisible
+    highlighter:for_each_highlight_state(win, callback)
+  else
+    ---@diagnostic disable-next-line: invisible
+    highlighter:for_each_highlight_state(callback)
+  end
 end
 
 return TSOverride

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -179,7 +179,7 @@ end
 TSOverride.is_unused = function(self, bufnr, row, col)
   local range_list = self.diagnostics_map[bufnr][row]
   for _, range in list.iter(range_list) do
-    if range.start_col <= col and col <= range.end_col then
+    if range.start_col <= col and col < range.end_col then
       return true
     end
   end

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -70,11 +70,15 @@ TSOverride.set_override_win = function(self)
     end
 
     lsp.for_each_token(bufnr, top, bottom, function(ns, token)
-      if
-          self.diagnostics_map[bufnr][token.line]
-          and token.neodim_version ~= version.num
-          and self:is_unused(bufnr, token.line, token.start_col)
-      then
+      local map_buf = self.diagnostics_map[bufnr]
+      if not map_buf[token.line] then
+        for i = token.line + 1, bottom do
+          if map_buf[i] then
+            return i
+          end
+        end
+        return false
+      elseif token.neodim_version ~= version.num and self:is_unused(bufnr, token.line, token.start_col) then
         self:override_mark_with_lsp(bufnr, ns, token)
         token.neodim_version = version.num ---@diagnostic disable-line: inject-field
       end

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -32,7 +32,6 @@ TSOverride.init = function()
   vim.api.nvim_set_decoration_provider(NAMESPACE, {
     on_win = TSHighlighter._on_win, ---@diagnostic disable-line: invisible
     on_line = self:set_override(),
-    _on_spell_nav = TSHighlighter._on_spell_nav, ---@diagnostic disable-line: invisible
   })
   vim.api.nvim_create_autocmd('ColorScheme', {
     callback = function()

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -26,12 +26,14 @@ TSOverride.init = function()
     diagnostics_map = {},
     highlight_cache = {},
   }, TSOverride)
+  local use_range = vim.fn.has 'nvim-0.12' == 1
 
   -- these are 'private' but technically accessible
   -- if that every changes, we will have to override the whole TSHighlighter
   vim.api.nvim_set_decoration_provider(NAMESPACE, {
     on_win = TSHighlighter._on_win, ---@diagnostic disable-line: invisible
-    on_line = self:set_override(),
+    on_line = not use_range and self:set_override_line() or nil,
+    on_range = use_range and self:set_override_range() or nil,
   })
   vim.api.nvim_create_autocmd('ColorScheme', {
     callback = function()
@@ -46,20 +48,36 @@ TSOverride.init = function()
 end
 
 ---@return function
-TSOverride.set_override = function(self)
+TSOverride.set_override_line = function(self)
+  local on_range = self:set_override_range()
   ---@param win integer
   ---@param buf integer
   ---@param line integer
   local function on_line(_, win, buf, line)
+    on_range('range', win, buf, line, 0, line + 1, 0)
+  end
+
+  return on_line
+end
+
+---@return function
+TSOverride.set_override_range = function(self)
+  ---@param win integer
+  ---@param buf integer
+  ---@param br integer
+  ---@param bc integer
+  ---@param er integer
+  ---@param ec integer
+  local function on_range(_, win, buf, br, bc, er, ec)
     local highlighter = TSHighlighter.active[buf]
     if not highlighter then
       return
     end
 
-    self:on_line_impl(highlighter, win, buf, line)
+    return self:on_range_impl(highlighter, win, buf, br, bc, er, ec)
   end
 
-  return on_line
+  return on_range
 end
 
 ---@param diagnostics vim.Diagnostic[]
@@ -180,7 +198,7 @@ TSOverride.override_mark_with_ts = function(self, mark, buf, start_row, start_co
   else
     mark.hl_group = hl
     mark.priority = (tonumber(metadata.priority) or vim.highlight.priorities.treesitter)
-      + (capture_name == 'nospell' and 1 or 0)
+        + (capture_name == 'nospell' and 1 or 0)
   end
 
   if capture_name == 'spell' then
@@ -195,40 +213,58 @@ end
 ---@param highlighter vim.treesitter.highlighter
 ---@param win integer
 ---@param buf integer
----@param line integer
-TSOverride.on_line_impl = function(self, highlighter, win, buf, line)
+---@param range_start_row integer
+---@param range_start_col integer
+---@param range_end_row integer
+---@param range_end_col integer
+TSOverride.on_range_impl = function(
+    self,
+    highlighter,
+    win,
+    buf,
+    range_start_row,
+    range_start_col,
+    range_end_row,
+    range_end_col
+)
+  ---@diagnostic disable-next-line: invisible
+  ---@param state vim.treesitter.highlighter.State
   local function callback(state)
     local root_node = state.tstree:root()
+    ---@type { [1]: integer, [2]: integer, [3]: integer, [4]: integer }
+    local root_range = { root_node:range() }
 
-    local root_start_row, _, root_end_row, _ = root_node:range()
-    if line < root_start_row or root_end_row < line then
+    if not Range.intercepts(root_range, { range_start_row, range_start_col, range_end_row, range_end_col }) then
       return
     end
 
     local query = state.highlighter_query:query()
-    for capture, node, metadata in query:iter_captures(root_node, highlighter.bufnr, line, line + 1) do
+    local iter = query:iter_captures(
+      root_node,
+      buf,
+      range_start_row,
+      range_end_row,
+      { start_col = range_start_col, end_col = range_end_col }
+    )
+    for capture, node, metadata in iter do
       local range = vim.treesitter.get_range(node, buf, metadata[capture])
-      ---@type integer, integer, integer, integer
       local start_row, start_col, end_row, end_col = Range.unpack4(range)
-
-      if line <= end_row then
-        ---@type vim.api.keyset.set_extmark
-        local mark = {
-          end_line = end_row,
-          end_col = end_col,
-          ephemeral = true,
-          conceal = metadata.conceal,
-        }
-        if
+      ---@type vim.api.keyset.set_extmark
+      local mark = {
+        end_row = end_row,
+        end_col = end_col,
+        ephemeral = true,
+        conceal = metadata.conceal or metadata[capture] and metadata[capture].conceal,
+      }
+      if
           self:override_mark_with_lsp(mark, buf, start_row, start_col)
           or self:override_mark_with_ts(mark, buf, start_row, start_col, state.highlighter_query, capture, metadata)
-        then
-          vim.api.nvim_buf_set_extmark(buf, NAMESPACE, start_row, start_col, mark)
-        end
+      then
+        vim.api.nvim_buf_set_extmark(buf, NAMESPACE, start_row, start_col, mark)
       end
     end
   end
-  if vim.fn.has 'nvim-0.11.3' == 1 then
+  if vim.fn.has 'nvim-0.11.3' == 1 and vim.fn.has 'nvim-0.12' == 0 then
     ---@diagnostic disable-next-line: invisible
     highlighter:for_each_highlight_state(win, callback)
   else

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -60,7 +60,8 @@ TSOverride.set_override_win = function(self)
   ---@param bottom integer
   local function on_win(_, winid, bufnr, top, bottom)
     TSHighlighter._on_win(_, winid, bufnr, top, bottom) ---@diagnostic disable-line: invisible
-    if not self.diagnostics_map[bufnr] then
+    local map_buf = self.diagnostics_map[bufnr]
+    if not map_buf then
       return false
     end
     local version = self.version_num[bufnr]
@@ -69,8 +70,19 @@ TSOverride.set_override_win = function(self)
       version.cleared = true
     end
 
+    for i = top, bottom do
+      if map_buf[i] then
+        top = i
+        break
+      end
+    end
+    for i = bottom, top, -1 do
+      if map_buf[i] then
+        bottom = i
+        break
+      end
+    end
     lsp.for_each_token(bufnr, top, bottom, function(ns, token)
-      local map_buf = self.diagnostics_map[bufnr]
       if not map_buf[token.line] then
         for i = token.line + 1, bottom do
           if map_buf[i] then

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -31,7 +31,7 @@ TSOverride.init = function()
   -- these are 'private' but technically accessible
   -- if that every changes, we will have to override the whole TSHighlighter
   vim.api.nvim_set_decoration_provider(NAMESPACE, {
-    on_win = TSHighlighter._on_win, ---@diagnostic disable-line: invisible
+    on_win = self:set_override_win(),
     on_line = not use_range and self:set_override_line() or nil,
     on_range = use_range and self:set_override_range() or nil,
   })
@@ -45,6 +45,30 @@ TSOverride.init = function()
   })
 
   return self
+end
+
+---@return function
+TSOverride.set_override_win = function(self)
+  ---@param winid integer
+  ---@param bufnr integer
+  ---@param top integer
+  ---@param bottom integer
+  local function on_win(_, winid, bufnr, top, bottom)
+    TSHighlighter._on_win(_, winid, bufnr, top, bottom) ---@diagnostic disable-line: invisible
+    local map_buf = self.diagnostics_map[bufnr]
+    if not map_buf then
+      return false
+    end
+    for i = top, bottom do
+      local range_list = map_buf[i]
+      if range_list and range_list[1] then
+        return true
+      end
+    end
+    return false
+  end
+
+  return on_win
 end
 
 ---@return function

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -6,7 +6,8 @@ local config = require 'neodim.config'
 local list = require 'neodim.list'
 local lsp = require 'neodim.lsp'
 
-local NAMESPACE = vim.api.nvim_create_namespace 'treesitter/highlighter'
+local NAMESPACE = vim.api.nvim_create_namespace 'neodim.treesitter'
+local NAMESPACE_LSP = vim.api.nvim_create_namespace 'neodim.semantic_tokens'
 
 ---@class neodim.ColumnRange
 ---@field start_col integer
@@ -15,6 +16,7 @@ local NAMESPACE = vim.api.nvim_create_namespace 'treesitter/highlighter'
 ---@class neodim.TSOverride
 ---@field diagnostics_map table<integer, table<integer, neodim.ColumnRange[]>>
 ---@field highlight_cache table<string, string>
+---@field version_num table<integer, {num: integer, cleared: boolean}>
 local TSOverride = {}
 ---@private
 TSOverride.__index = TSOverride
@@ -28,6 +30,7 @@ TSOverride.init = function()
   local self = setmetatable({
     diagnostics_map = {},
     highlight_cache = {},
+    version_num = {},
   }, TSOverride)
 
   -- these are 'private' but technically accessible
@@ -60,6 +63,22 @@ TSOverride.set_override_win = function(self)
     if not self.diagnostics_map[bufnr] then
       return false
     end
+    local version = self.version_num[bufnr]
+    if not version.cleared then
+      vim.api.nvim_buf_clear_namespace(bufnr, NAMESPACE_LSP, 0, -1)
+      version.cleared = true
+    end
+
+    lsp.for_each_token(bufnr, top, bottom, function(client_id, token)
+      if
+          self.diagnostics_map[bufnr][token.line]
+          and token.neodim_version ~= version.num
+          and self:is_unused(bufnr, token.line, token.start_col)
+      then
+        self:override_mark_with_lsp(bufnr, client_id, token)
+        token.neodim_version = version.num ---@diagnostic disable-line: inject-field
+      end
+    end)
   end
 
   return on_win
@@ -139,6 +158,8 @@ TSOverride.update_unused = function(self, diagnostics, bufnr)
       list.insert(range_list, range)
     end
   end
+  local version = self.version_num[bufnr] or { num = 0 }
+  self.version_num[bufnr] = { num = version.num + 1, cleared = false }
 end
 
 ---@param row integer
@@ -168,19 +189,21 @@ TSOverride.get_dim_color = function(self, hl, hl_name)
   return self.highlight_cache[hl_name]
 end
 
----@param mark vim.api.keyset.set_extmark
 ---@param buf integer
----@param start_row integer
----@param start_col integer
----@return boolean
-TSOverride.override_mark_with_lsp = function(self, mark, buf, start_row, start_col)
-  local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, start_row, start_col)
+---@param client_id integer
+---@param token STTokenRange
+TSOverride.override_mark_with_lsp = function(self, buf, client_id, token)
+  local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, client_id, token)
   if sttoken_mark_data then
-    mark.hl_group = self:get_dim_color(sttoken_mark_data.hl_opts, sttoken_mark_data.hl_name)
-    mark.priority = config.opts.priority
-    return true
+    local hl_group = self:get_dim_color(sttoken_mark_data.hl_opts, sttoken_mark_data.hl_name)
+    vim.api.nvim_buf_set_extmark(buf, NAMESPACE_LSP, token.line, token.start_col, {
+      hl_group = hl_group,
+      end_line = token.end_line,
+      end_col = token.end_col,
+      priority = config.opts.priority + 10,
+      strict = false,
+    })
   end
-  return false
 end
 
 ---@param mark vim.api.keyset.set_extmark
@@ -253,17 +276,14 @@ TSOverride.on_range_impl = function(
       }
       if
           self:is_unused(buf, start_row, start_col)
-          and (
-            self:override_mark_with_lsp(mark, buf, start_row, start_col)
-            or self:override_mark_with_ts(mark, state.highlighter_query, capture)
-          )
+          and self:override_mark_with_ts(mark, state.highlighter_query, capture)
       then
         vim.api.nvim_buf_set_extmark(buf, NAMESPACE, start_row, start_col, mark)
       end
     end
   end
   if use_line_win then
-    highlighter:for_each_highlight_state(win, callback)  ---@diagnostic disable-line: invisible
+    highlighter:for_each_highlight_state(win, callback) ---@diagnostic disable-line: invisible
   else
     highlighter:for_each_highlight_state(callback) ---@diagnostic disable-line: invisible
   end

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -197,20 +197,15 @@ TSOverride.override_mark_with_lsp = function(self, mark, buf, start_row, start_c
 end
 
 ---@param mark vim.api.keyset.set_extmark
----@param buf integer
----@param start_row integer
----@param start_col integer
 ---@param hl_query vim.treesitter.highlighter.Query
 ---@param capture integer
----@param metadata vim.treesitter.query.TSMetadata
 ---@return boolean
-TSOverride.override_mark_with_ts = function(self, mark, buf, start_row, start_col, hl_query, capture, metadata)
+TSOverride.override_mark_with_ts = function(self, mark, hl_query, capture)
   ---@diagnostic disable-next-line: invisible
   local hl = hl_query:get_hl_from_capture(capture)
   if not hl or hl == 0 then
     return false
   end
-  ---@diagnostic disable-next-line: invisible
   local capture_name = hl_query:query().captures[capture]
   mark.hl_group = self:get_dim_color(
     vim.api.nvim_get_hl(0, { id = hl, link = false }) --[[@as vim.api.keyset.highlight]],
@@ -269,7 +264,7 @@ TSOverride.on_range_impl = function(
           self:is_unused(buf, start_row, start_col)
           and (
             self:override_mark_with_lsp(mark, buf, start_row, start_col)
-            or self:override_mark_with_ts(mark, buf, start_row, start_col, state.highlighter_query, capture, metadata)
+            or self:override_mark_with_ts(mark, state.highlighter_query, capture)
           )
       then
         vim.api.nvim_buf_set_extmark(buf, NAMESPACE, start_row, start_col, mark)

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -57,17 +57,9 @@ TSOverride.set_override_win = function(self)
   ---@param bottom integer
   local function on_win(_, winid, bufnr, top, bottom)
     TSHighlighter._on_win(_, winid, bufnr, top, bottom) ---@diagnostic disable-line: invisible
-    local map_buf = self.diagnostics_map[bufnr]
-    if not map_buf then
+    if not self.diagnostics_map[bufnr] then
       return false
     end
-    for i = top, bottom do
-      local range_list = map_buf[i]
-      if range_list and range_list[1] then
-        return true
-      end
-    end
-    return false
   end
 
   return on_win
@@ -153,14 +145,7 @@ end
 ---@param col integer
 ---@return boolean
 TSOverride.is_unused = function(self, bufnr, row, col)
-  local map_buf = self.diagnostics_map[bufnr]
-  if not map_buf then
-    return false
-  end
-  local range_list = map_buf[row]
-  if not range_list then
-    return false
-  end
+  local range_list = self.diagnostics_map[bufnr][row]
   for _, range in list.iter(range_list) do
     if range.start_col <= col and col <= range.end_col then
       return true
@@ -234,6 +219,10 @@ TSOverride.on_range_impl = function(
     range_end_row,
     range_end_col
 )
+  if not self.diagnostics_map[buf][range_start_row] then
+    return
+  end
+
   ---@diagnostic disable-next-line: invisible
   ---@param state vim.treesitter.highlighter.State
   local function callback(state)
@@ -274,11 +263,9 @@ TSOverride.on_range_impl = function(
     end
   end
   if use_line_win then
-    ---@diagnostic disable-next-line: invisible
-    highlighter:for_each_highlight_state(win, callback)
+    highlighter:for_each_highlight_state(win, callback)  ---@diagnostic disable-line: invisible
   else
-    ---@diagnostic disable-next-line: invisible
-    highlighter:for_each_highlight_state(callback)
+    highlighter:for_each_highlight_state(callback) ---@diagnostic disable-line: invisible
   end
 end
 

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -13,7 +13,7 @@ local NAMESPACE = vim.api.nvim_create_namespace 'treesitter/highlighter'
 ---@field end_col integer
 
 ---@class neodim.TSOverride
----@field diagnostics_map table<buffer, table<integer, neodim.ColumnRange[]>>
+---@field diagnostics_map table<integer, table<integer, neodim.ColumnRange[]>>
 ---@field highlight_cache table<string, string>
 local TSOverride = {}
 ---@private

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -19,6 +19,9 @@ local TSOverride = {}
 ---@private
 TSOverride.__index = TSOverride
 
+local use_range = vim.fn.has 'nvim-0.12' == 1
+local use_line_win = vim.fn.has 'nvim-0.11.3' == 1 and not use_range
+
 ---@return self
 TSOverride.init = function()
   ---@type neodim.TSOverride
@@ -26,7 +29,6 @@ TSOverride.init = function()
     diagnostics_map = {},
     highlight_cache = {},
   }, TSOverride)
-  local use_range = vim.fn.has 'nvim-0.12' == 1
 
   -- these are 'private' but technically accessible
   -- if that every changes, we will have to override the whole TSHighlighter
@@ -271,7 +273,7 @@ TSOverride.on_range_impl = function(
       end
     end
   end
-  if vim.fn.has 'nvim-0.11.3' == 1 and vim.fn.has 'nvim-0.12' == 0 then
+  if use_line_win then
     ---@diagnostic disable-next-line: invisible
     highlighter:for_each_highlight_state(win, callback)
   else

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -195,19 +195,9 @@ TSOverride.override_mark_with_ts = function(self, mark, buf, start_row, start_co
       '@' .. capture_name
     )
     mark.priority = config.opts.priority
-  else
-    mark.hl_group = hl
-    mark.priority = (tonumber(metadata.priority) or vim.highlight.priorities.treesitter)
-        + (capture_name == 'nospell' and 1 or 0)
+    return true
   end
-
-  if capture_name == 'spell' then
-    mark.spell = true
-  elseif capture_name == 'nospell' then
-    mark.spell = false
-  end
-
-  return true
+  return false
 end
 
 ---@param highlighter vim.treesitter.highlighter
@@ -254,7 +244,6 @@ TSOverride.on_range_impl = function(
         end_row = end_row,
         end_col = end_col,
         ephemeral = true,
-        conceal = metadata.conceal or metadata[capture] and metadata[capture].conceal,
       }
       if
           self:override_mark_with_lsp(mark, buf, start_row, start_col)

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -69,13 +69,13 @@ TSOverride.set_override_win = function(self)
       version.cleared = true
     end
 
-    lsp.for_each_token(bufnr, top, bottom, function(client_id, token)
+    lsp.for_each_token(bufnr, top, bottom, function(ns, token)
       if
           self.diagnostics_map[bufnr][token.line]
           and token.neodim_version ~= version.num
           and self:is_unused(bufnr, token.line, token.start_col)
       then
-        self:override_mark_with_lsp(bufnr, client_id, token)
+        self:override_mark_with_lsp(bufnr, ns, token)
         token.neodim_version = version.num ---@diagnostic disable-line: inject-field
       end
     end)
@@ -190,10 +190,10 @@ TSOverride.get_dim_color = function(self, hl, hl_name)
 end
 
 ---@param buf integer
----@param client_id integer
+---@param ns integer
 ---@param token STTokenRange
-TSOverride.override_mark_with_lsp = function(self, buf, client_id, token)
-  local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, client_id, token)
+TSOverride.override_mark_with_lsp = function(self, buf, ns, token)
+  local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, ns, token)
   if sttoken_mark_data then
     local hl_group = self:get_dim_color(sttoken_mark_data.hl_opts, sttoken_mark_data.hl_name)
     vim.api.nvim_buf_set_extmark(buf, NAMESPACE_LSP, token.line, token.start_col, {

--- a/lua/neodim/TSOverride.lua
+++ b/lua/neodim/TSOverride.lua
@@ -7,7 +7,6 @@ local list = require 'neodim.list'
 local lsp = require 'neodim.lsp'
 
 local NAMESPACE = vim.api.nvim_create_namespace 'neodim.treesitter'
-local NAMESPACE_LSP = vim.api.nvim_create_namespace 'neodim.semantic_tokens'
 
 ---@class neodim.ColumnRange
 ---@field start_col integer
@@ -16,7 +15,7 @@ local NAMESPACE_LSP = vim.api.nvim_create_namespace 'neodim.semantic_tokens'
 ---@class neodim.TSOverride
 ---@field diagnostics_map table<integer, table<integer, neodim.ColumnRange[]>>
 ---@field highlight_cache table<string, string>
----@field version_num table<integer, {num: integer, cleared: boolean}>
+---@field version_num table<integer, integer>
 local TSOverride = {}
 ---@private
 TSOverride.__index = TSOverride
@@ -65,10 +64,6 @@ TSOverride.set_override_win = function(self)
       return false
     end
     local version = self.version_num[bufnr]
-    if not version.cleared then
-      vim.api.nvim_buf_clear_namespace(bufnr, NAMESPACE_LSP, 0, -1)
-      version.cleared = true
-    end
 
     for i = top, bottom do
       if map_buf[i] then
@@ -82,7 +77,7 @@ TSOverride.set_override_win = function(self)
         break
       end
     end
-    lsp.for_each_token(bufnr, top, bottom, function(ns, token)
+    lsp.for_each_token(bufnr, version, top, bottom, function(client_id, token)
       if not map_buf[token.line] then
         for i = token.line + 1, bottom do
           if map_buf[i] then
@@ -90,9 +85,9 @@ TSOverride.set_override_win = function(self)
           end
         end
         return false
-      elseif token.neodim_version ~= version.num and self:is_unused(bufnr, token.line, token.start_col) then
-        self:override_mark_with_lsp(bufnr, ns, token)
-        token.neodim_version = version.num ---@diagnostic disable-line: inject-field
+      elseif token.neodim_version ~= version and self:is_unused(bufnr, token.line, token.start_col) then
+        self:override_mark_with_lsp(bufnr, client_id, token)
+        token.neodim_version = version ---@diagnostic disable-line: inject-field
       end
     end)
   end
@@ -174,8 +169,8 @@ TSOverride.update_unused = function(self, diagnostics, bufnr)
       list.insert(range_list, range)
     end
   end
-  local version = self.version_num[bufnr] or { num = 0 }
-  self.version_num[bufnr] = { num = version.num + 1, cleared = false }
+  local version = self.version_num[bufnr] or 0
+  self.version_num[bufnr] = version + 1
 end
 
 ---@param row integer
@@ -206,19 +201,13 @@ TSOverride.get_dim_color = function(self, hl, hl_name)
 end
 
 ---@param buf integer
----@param ns integer
+---@param client_id integer
 ---@param token STTokenRange
-TSOverride.override_mark_with_lsp = function(self, buf, ns, token)
-  local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, ns, token)
+TSOverride.override_mark_with_lsp = function(self, buf, client_id, token)
+  local sttoken_mark_data = lsp.get_sttoken_mark_data(buf, client_id, token)
   if sttoken_mark_data then
     local hl_group = self:get_dim_color(sttoken_mark_data.hl_opts, sttoken_mark_data.hl_name)
-    vim.api.nvim_buf_set_extmark(buf, NAMESPACE_LSP, token.line, token.start_col, {
-      hl_group = hl_group,
-      end_line = token.end_line,
-      end_col = token.end_col,
-      priority = config.opts.priority + 10,
-      strict = false,
-    })
+    lsp.highlight(token, buf, client_id, hl_group, config.opts.priority + 10)
   end
 end
 

--- a/lua/neodim/init.lua
+++ b/lua/neodim/init.lua
@@ -37,6 +37,7 @@ dim.setup = function(opts)
       ts_override:update_unused(filter.get_unused(vim.diagnostic.get(bufnr)), bufnr)
     end,
   }
+  require('neodim.lsp').attach_previous()
 end
 
 return dim

--- a/lua/neodim/init.lua
+++ b/lua/neodim/init.lua
@@ -30,8 +30,8 @@ dim.setup = function(opts)
   end
   local ts_override = TSOverride.init()
   vim.diagnostic.handlers['dim/unused'] = {
-    show = function(_, bufnr, diagnostics, _)
-      ts_override:update_unused(filter.get_unused(diagnostics), bufnr)
+    show = function(_, bufnr, _, _)
+      ts_override:update_unused(filter.get_unused(vim.diagnostic.get(bufnr)), bufnr)
     end,
     hide = function(_, bufnr)
       ts_override:update_unused({}, bufnr)

--- a/lua/neodim/init.lua
+++ b/lua/neodim/init.lua
@@ -30,11 +30,11 @@ dim.setup = function(opts)
   end
   local ts_override = TSOverride.init()
   vim.diagnostic.handlers['dim/unused'] = {
-    show = function(_, bufnr, _, _)
-      ts_override:update_unused(filter.get_unused(vim.diagnostic.get(bufnr)), bufnr)
+    show = function(_, bufnr, diagnostics, _)
+      ts_override:update_unused(filter.get_unused(diagnostics), bufnr)
     end,
     hide = function(_, bufnr)
-      ts_override:update_unused({}, bufnr)
+      ts_override:update_unused(filter.get_unused(vim.diagnostic.get(bufnr)), bufnr)
     end,
   }
 end

--- a/lua/neodim/lsp.lua
+++ b/lua/neodim/lsp.lua
@@ -102,7 +102,7 @@ end
 ---@param buf integer
 ---@param topline integer
 ---@param botline integer
----@param fn fun(ns: integer, token: STTokenRange)
+---@param fn fun(ns: integer, token: STTokenRange): integer|boolean|nil
 function M.for_each_token(buf, topline, botline, fn)
   local self = STHighlighter.active[buf]
   if not self then
@@ -130,12 +130,25 @@ function M.for_each_token(buf, topline, botline, fn)
       --- @type boolean?, integer?
       local is_folded, foldend
 
-      for i = first, last do
+      local i = first
+      while i <= last do
         local token = assert(highlights[i])
         is_folded, foldend = check_fold(token.line + 1, foldend)
         if not is_folded then
-          fn(state.namespace, token)
+          local next_line = fn(state.namespace, token)
+          if next_line == false then
+            return
+          elseif next_line then
+            i = vim_list.bisect(highlights, { end_line = next_line }, {
+              lo = i + 1,
+              hi = last + 1,
+              key = function(highlight)
+                return highlight.end_line
+              end,
+            }) - 1
+          end
         end
+        i = i + 1
       end
     end
   end

--- a/lua/neodim/lsp.lua
+++ b/lua/neodim/lsp.lua
@@ -7,8 +7,6 @@ local vim_list = vim.list or {}
 
 local M = {}
 
-local ns_name_prefix = vim.fn.has 'nvim-0.11' == 1 and 'nvim.lsp.semantic_tokens:' or 'vim_lsp_semantic_tokens:'
-
 -- NOTE: backported from nvim 0.12
 -- TODO: remove when dropping support for nvim 0.11
 if vim.fn.has 'nvim-0.12' == 0 then
@@ -104,13 +102,13 @@ end
 ---@param buf integer
 ---@param topline integer
 ---@param botline integer
----@param fn fun(client_id: integer, token: STTokenRange)
+---@param fn fun(ns: integer, token: STTokenRange)
 function M.for_each_token(buf, topline, botline, fn)
   local self = STHighlighter.active[buf]
   if not self then
     return
   end
-  for client_id, state in pairs(self.client_state) do
+  for _, state in pairs(self.client_state) do
     local current_result = state.current_result
     if current_result.version == util.buf_versions[self.bufnr] then
       local highlights = assert(current_result.highlights)
@@ -136,7 +134,7 @@ function M.for_each_token(buf, topline, botline, fn)
         local token = assert(highlights[i])
         is_folded, foldend = check_fold(token.line + 1, foldend)
         if not is_folded then
-          fn(client_id, token)
+          fn(state.namespace, token)
         end
       end
     end
@@ -158,15 +156,14 @@ end
 ---@field end_row integer
 
 ---@param buf integer
----@param client_id integer
+---@param ns integer
 ---@param token_range STTokenRange
 ---@return extmark[]
-local function get_sttoken_extmarks(buf, client_id, token_range)
+local function get_sttoken_extmarks(buf, ns, token_range)
   local start = { token_range.line, token_range.start_col }
   local end_ = { token_range.line, token_range.end_col }
   local opts = { type = 'highlight', details = true }
-  local ns_id = vim.api.nvim_create_namespace(ns_name_prefix .. client_id)
-  return list.from_raw(api.nvim_buf_get_extmarks(buf, ns_id, start, end_, opts))
+  return list.from_raw(api.nvim_buf_get_extmarks(buf, ns, start, end_, opts))
 end
 
 ---@param extmarks extmark[]
@@ -198,11 +195,11 @@ local function get_max_pri_extmark(extmarks)
 end
 
 ---@param buf integer
----@param client_id integer
+---@param ns integer
 ---@param token STTokenRange
 ---@return extmark_data?
-function M.get_sttoken_mark_data(buf, client_id, token)
-  local extmarks = get_sttoken_extmarks(buf, client_id, token)
+function M.get_sttoken_mark_data(buf, ns, token)
+  local extmarks = get_sttoken_extmarks(buf, ns, token)
   return get_max_pri_extmark(extmarks)
 end
 

--- a/lua/neodim/lsp.lua
+++ b/lua/neodim/lsp.lua
@@ -83,15 +83,28 @@ if vim.fn.has 'nvim-0.12' == 0 then
   end
 end
 
-vim.api.nvim_create_autocmd("LspAttach", {
+---@param client_id integer
+---@param buf integer
+local function on_attach(client_id, buf)
+  local ns = vim.api.nvim_create_namespace('neodim.semantic_tokens:' .. client_id)
+  local state = client_ns[buf] or {}
+  state[client_id] = ns
+  client_ns[buf] = state
+end
+
+vim.api.nvim_create_autocmd('LspAttach', {
   callback = function(ev)
-    local client_id = ev.data.client_id
-    local ns = vim.api.nvim_create_namespace('neodim.semantic_tokens:' .. client_id)
-    local state =  client_ns[ev.buf] or {}
-    state[client_id] = ns
-    client_ns[ev.buf] = state
-  end
+    on_attach(ev.data.client_id, ev.buf)
+  end,
 })
+
+function M.attach_previous()
+  for _, client in ipairs(vim.lsp.get_clients()) do
+    for buf, _ in pairs(client.attached_buffers) do
+      on_attach(client.id, buf)
+    end
+  end
+end
 
 --- @param lnum integer
 --- @param foldend integer?

--- a/lua/neodim/lsp.lua
+++ b/lua/neodim/lsp.lua
@@ -6,6 +6,7 @@ local list = require 'neodim.list'
 local vim_list = vim.list or {}
 
 local M = {}
+local client_ns = {}
 
 -- NOTE: backported from nvim 0.12
 -- TODO: remove when dropping support for nvim 0.11
@@ -82,6 +83,16 @@ if vim.fn.has 'nvim-0.12' == 0 then
   end
 end
 
+vim.api.nvim_create_autocmd("LspAttach", {
+  callback = function(ev)
+    local client_id = ev.data.client_id
+    local ns = vim.api.nvim_create_namespace('neodim.semantic_tokens:' .. client_id)
+    local state =  client_ns[ev.buf] or {}
+    state[client_id] = ns
+    client_ns[ev.buf] = state
+  end
+})
+
 --- @param lnum integer
 --- @param foldend integer?
 --- @return boolean, integer?
@@ -99,18 +110,38 @@ local function check_fold(lnum, foldend)
   return folded ~= lnum, vim.fn.foldclosedend(lnum)
 end
 
+---@param token STTokenRange
+---@param bufnr integer
+---@param client_id integer
+---@param hl_group string
+---@param priority integer
+function M.highlight(token, bufnr, client_id, hl_group, priority)
+  vim.api.nvim_buf_set_extmark(bufnr, client_ns[bufnr][client_id], token.line, token.start_col, {
+    hl_group = hl_group,
+    end_line = token.end_line,
+    end_col = token.end_col,
+    priority = priority,
+    strict = false,
+  })
+end
+
 ---@param buf integer
+---@param version integer
 ---@param topline integer
 ---@param botline integer
----@param fn fun(ns: integer, token: STTokenRange): integer|boolean|nil
-function M.for_each_token(buf, topline, botline, fn)
+---@param fn fun(client_id: integer, token: STTokenRange): integer|boolean|nil
+function M.for_each_token(buf, version, topline, botline, fn)
   local self = STHighlighter.active[buf]
   if not self then
     return
   end
-  for _, state in pairs(self.client_state) do
+  for client_id, state in pairs(self.client_state) do
     local current_result = state.current_result
     if current_result.version == util.buf_versions[self.bufnr] then
+      if current_result.neodim_version ~= version then
+        vim.api.nvim_buf_clear_namespace(self.bufnr, client_ns[buf][client_id], 0, -1)
+        current_result.neodim_version = version ---@diagnostic disable-line: inject-field
+      end
       local highlights = assert(current_result.highlights)
       -- NOTE: `end_line` was added in nvim 0.12
       -- TODO: remove `line` when dropping support for nvim 0.11
@@ -135,7 +166,7 @@ function M.for_each_token(buf, topline, botline, fn)
         local token = assert(highlights[i])
         is_folded, foldend = check_fold(token.line + 1, foldend)
         if not is_folded then
-          local next_line = fn(state.namespace, token)
+          local next_line = fn(client_id, token)
           if next_line == false then
             return
           elseif next_line then
@@ -169,13 +200,14 @@ end
 ---@field end_row integer
 
 ---@param buf integer
----@param ns integer
+---@param client_id integer
 ---@param token_range STTokenRange
 ---@return extmark[]
-local function get_sttoken_extmarks(buf, ns, token_range)
+local function get_sttoken_extmarks(buf, client_id, token_range)
   local start = { token_range.line, token_range.start_col }
   local end_ = { token_range.line, token_range.end_col }
   local opts = { type = 'highlight', details = true }
+  local ns = STHighlighter.active[buf].client_state[client_id].namespace
   return list.from_raw(api.nvim_buf_get_extmarks(buf, ns, start, end_, opts))
 end
 
@@ -208,11 +240,11 @@ local function get_max_pri_extmark(extmarks)
 end
 
 ---@param buf integer
----@param ns integer
+---@param client_id integer
 ---@param token STTokenRange
 ---@return extmark_data?
-function M.get_sttoken_mark_data(buf, ns, token)
-  local extmarks = get_sttoken_extmarks(buf, ns, token)
+function M.get_sttoken_mark_data(buf, client_id, token)
+  local extmarks = get_sttoken_extmarks(buf, client_id, token)
   return get_max_pri_extmark(extmarks)
 end
 

--- a/lua/neodim/lsp.lua
+++ b/lua/neodim/lsp.lua
@@ -18,7 +18,7 @@ local M = {}
 ---@field end_col integer
 ---@field end_row integer
 
----@param buf buffer
+---@param buf integer
 ---@param token_range STTokenRange
 ---@return extmark[]
 local function get_sttoken_extmarks(buf, token_range)
@@ -73,7 +73,7 @@ local function get_max_pri_extmark(extmarks)
   end
 end
 
----@param buf buffer
+---@param buf integer
 ---@param row integer
 ---@param col integer
 ---@return extmark_data?

--- a/lua/neodim/lsp.lua
+++ b/lua/neodim/lsp.lua
@@ -1,8 +1,147 @@
 local api = vim.api
+local util = vim.lsp.util
+local STHighlighter = vim.lsp.semantic_tokens.__STHighlighter
 
 local list = require 'neodim.list'
+local vim_list = vim.list or {}
 
 local M = {}
+
+local ns_name_prefix = vim.fn.has 'nvim-0.11' == 1 and 'nvim.lsp.semantic_tokens:' or 'vim_lsp_semantic_tokens:'
+
+-- NOTE: backported from nvim 0.12
+-- TODO: remove when dropping support for nvim 0.11
+if vim.fn.has 'nvim-0.12' == 0 then
+  ---@generic T
+  ---@param v T
+  ---@param key? fun(v: T): any
+  ---@return any
+  local function key_fn(v, key)
+    return key and key(v) or v
+  end
+
+  ---@generic T
+  ---@param t T[]
+  ---@param val T
+  ---@param key? fun(val: any): any
+  ---@param lo integer
+  ---@param hi integer
+  ---@return integer i
+  local function lower_bound(t, val, lo, hi, key)
+    local bit = require 'bit' -- Load bitop on demand
+    local val_key = key_fn(val, key)
+    while lo < hi do
+      local mid = bit.rshift(lo + hi, 1) -- Equivalent to floor((lo + hi) / 2)
+      if key_fn(t[mid], key) < val_key then
+        lo = mid + 1
+      else
+        hi = mid
+      end
+    end
+    return lo
+  end
+
+  ---@generic T
+  ---@param t T[]
+  ---@param val T
+  ---@param key? fun(val: any): any
+  ---@param lo integer
+  ---@param hi integer
+  ---@return integer i
+  local function upper_bound(t, val, lo, hi, key)
+    local bit = require 'bit' -- Load bitop on demand
+    local val_key = key_fn(val, key)
+    while lo < hi do
+      local mid = bit.rshift(lo + hi, 1) -- Equivalent to floor((lo + hi) / 2)
+      if val_key < key_fn(t[mid], key) then
+        hi = mid
+      else
+        lo = mid + 1
+      end
+    end
+    return lo
+  end
+
+  ---@generic T
+  ---@param t T[] A comparable list.
+  ---@param val T The value to search.
+  ---@param opts? vim.list.bisect.Opts
+  ---@return integer index serves as either the lower bound or the upper bound position.
+  function vim_list.bisect(t, val, opts)
+    vim.validate('t', t, 'table')
+    vim.validate('opts', opts, 'table', true)
+
+    opts = opts or {}
+    local lo = opts.lo or 1
+    local hi = opts.hi or #t + 1
+    local key = opts.key
+
+    if opts.bound == 'upper' then
+      return upper_bound(t, val, lo, hi, key)
+    else
+      return lower_bound(t, val, lo, hi, key)
+    end
+  end
+end
+
+--- @param lnum integer
+--- @param foldend integer?
+--- @return boolean, integer?
+local function check_fold(lnum, foldend)
+  if foldend and lnum <= foldend then
+    return true, foldend
+  end
+
+  local folded = vim.fn.foldclosed(lnum)
+
+  if folded == -1 then
+    return false, nil
+  end
+
+  return folded ~= lnum, vim.fn.foldclosedend(lnum)
+end
+
+---@param buf integer
+---@param topline integer
+---@param botline integer
+---@param fn fun(client_id: integer, token: STTokenRange)
+function M.for_each_token(buf, topline, botline, fn)
+  local self = STHighlighter.active[buf]
+  if not self then
+    return
+  end
+  for client_id, state in pairs(self.client_state) do
+    local current_result = state.current_result
+    if current_result.version == util.buf_versions[self.bufnr] then
+      local highlights = assert(current_result.highlights)
+      -- NOTE: `end_line` was added in nvim 0.12
+      -- TODO: remove `line` when dropping support for nvim 0.11
+      local first = vim_list.bisect(highlights, { line = topline, end_line = topline }, {
+        key = function(highlight)
+          return highlight.end_line or highlight.line
+        end,
+      })
+      local last = vim_list.bisect(highlights, { line = botline }, {
+        lo = first,
+        bound = 'upper',
+        key = function(highlight)
+          return highlight.line
+        end,
+      }) - 1
+
+      --- @type boolean?, integer?
+      local is_folded, foldend
+
+      for i = first, last do
+        local token = assert(highlights[i])
+        is_folded, foldend = check_fold(token.line + 1, foldend)
+        if not is_folded then
+          fn(client_id, token)
+        end
+      end
+    end
+  end
+end
 
 ---@alias extmark_data { priority: integer, hl_name: string, hl_opts: table }?
 
@@ -19,30 +158,15 @@ local M = {}
 ---@field end_row integer
 
 ---@param buf integer
+---@param client_id integer
 ---@param token_range STTokenRange
 ---@return extmark[]
-local function get_sttoken_extmarks(buf, token_range)
-  -- NOTE: vim.lsp.get_active_clients() was renamed to get_clients() and deprecated on Neovim v0.10
-  ---@diagnostic disable-next-line: deprecated
-  local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
-  ---@type table<integer, true>
-  local client_ids = {}
-  for _, client in pairs(get_clients { bufnr = buf }) do
-    client_ids[client.id] = true
-  end
-
+local function get_sttoken_extmarks(buf, client_id, token_range)
   local start = { token_range.line, token_range.start_col }
   local end_ = { token_range.line, token_range.end_col }
   local opts = { type = 'highlight', details = true }
-  ---@type extmark[]
-  local extmarks = list.new()
-  for name, ns_id in pairs(vim.api.nvim_get_namespaces()) do
-    local client_id = name:sub(#'vim_lsp_semantic_tokens:')
-    if client_ids[tonumber(client_id)] then
-      list.extend(extmarks, list.from_raw(api.nvim_buf_get_extmarks(buf, ns_id, start, end_, opts)))
-    end
-  end
-  return extmarks
+  local ns_id = vim.api.nvim_create_namespace(ns_name_prefix .. client_id)
+  return list.from_raw(api.nvim_buf_get_extmarks(buf, ns_id, start, end_, opts))
 end
 
 ---@param extmarks extmark[]
@@ -74,25 +198,12 @@ local function get_max_pri_extmark(extmarks)
 end
 
 ---@param buf integer
----@param row integer
----@param col integer
+---@param client_id integer
+---@param token STTokenRange
 ---@return extmark_data?
-function M.get_sttoken_mark_data(buf, row, col)
-  local max_priority = 0
-  ---@type extmark_data?
-  local mark_data
-
-  ---@type STTokenRange[]?
-  local token_ranges = vim.lsp.semantic_tokens.get_at_pos(buf, row, col)
-  for _, token_range in ipairs(token_ranges or {}) do
-    local extmarks = get_sttoken_extmarks(buf, token_range)
-    local info = get_max_pri_extmark(extmarks)
-    if info and info.priority > max_priority then
-      mark_data = info
-    end
-  end
-
-  return mark_data
+function M.get_sttoken_mark_data(buf, client_id, token)
+  local extmarks = get_sttoken_extmarks(buf, client_id, token)
+  return get_max_pri_extmark(extmarks)
 end
 
 return M


### PR DESCRIPTION
Fixes the plugin to work on neovim 0.11/0.12. I had to replace the caching of the treesitter captures iterator for reuse in multiple lines (at least i think that's what the old code was supposed to do) with making a new iterator for each individual line. Not sure what's the performance difference, but at least the new version works on both neovim 0.10 and 0.11/0.12 rather than just 0.10

Closes #47 